### PR TITLE
Add class methods for finding videos in a given state

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Transmuxer.config do |c|
   c.s3.bucket_name = "S3_BUCKET_NAME"
 end
 ```
-### Add to AR model
+### Add to Active Record model
 
 ```ruby
 class Medium < ActiveRecord::Base
@@ -65,6 +65,13 @@ class Medium < ActiveRecord::Base
   end
 end
 ```
+
+#### Additional class methods
+
+`Transmuxer::Transmuxable` adds several class methods for finding objects that match a given state:
+
+* `.processed` returns videos that have finished processing.
+* `.failed` returns videos that failed processing.
 
 ### Start Transmuxing
 

--- a/lib/transmuxer/engine.rb
+++ b/lib/transmuxer/engine.rb
@@ -1,3 +1,5 @@
+require 'rails/engine'
+
 module Transmuxer
   class Engine < ::Rails::Engine
   end

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -20,10 +20,6 @@ module Transmuxer
         where(zencoder_job_state: ['playback_ready', 'finished'])
       end
 
-      def processed
-        where(zencoder_job_state: 'finished')
-      end
-
       def transmuxable(unprocessed_file_url)
         define_method :unprocessed_file_url do
           send unprocessed_file_url

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -50,6 +50,7 @@ module Transmuxer
 
     def update_playable(playable_format)
       self.playable_formats[playable_format] = true
+      self.zencoder_job_state = "playback_ready" if playable? && !processed?
       self.save
 
       run_callbacks :playable if playable?

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -16,6 +16,10 @@ module Transmuxer
         where(zencoder_job_state: 'failed')
       end
 
+      def ready
+        where(zencoder_job_state: ['playback_ready', 'finished'])
+      end
+
       def processed
         where(zencoder_job_state: 'finished')
       end

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -12,6 +12,14 @@ module Transmuxer
     end
 
     module ClassMethods
+      def failed
+        where(zencoder_job_state: 'failed')
+      end
+
+      def processed
+        where(zencoder_job_state: 'finished')
+      end
+
       def transmuxable(unprocessed_file_url)
         define_method :unprocessed_file_url do
           send unprocessed_file_url

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'active_record'
+require 'transmuxer'
+
+ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+
+require 'support/models'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,0 +1,8 @@
+require 'active_record'
+
+load File.dirname(__FILE__) + '/schema.rb'
+
+# A transmuxable model
+class Video < ActiveRecord::Base
+  include Transmuxer::Transmuxable
+end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,0 +1,8 @@
+ActiveRecord::Schema.define do
+  self.verbose = false
+
+  create_table :videos, force: true do |t|
+    t.string :zencoder_job_state
+    t.timestamps null: false
+  end
+end

--- a/spec/transmuxer/transmuxable_spec.rb
+++ b/spec/transmuxer/transmuxable_spec.rb
@@ -15,6 +15,7 @@ module Transmuxer
     describe '.failed' do
       it 'returns videos that failed processing' do
         Video.create(zencoder_job_state: 'processing')
+        Video.create(zencoder_job_state: 'playback_ready')
         Video.create(zencoder_job_state: 'finished')
 
         match = Video.create(zencoder_job_state: 'failed')
@@ -23,10 +24,23 @@ module Transmuxer
       end
     end
 
+    describe '.ready' do
+      it 'returns videos that can be streamed' do
+        Video.create(zencoder_job_state: 'failed')
+        Video.create(zencoder_job_state: 'processing')
+
+        playback_ready = Video.create(zencoder_job_state: 'playback_ready')
+        processed      = Video.create(zencoder_job_state: 'finished')
+
+        expect(Video.ready).to eq([playback_ready, processed])
+      end
+    end
+
     describe '.processed' do
       it 'returns videos that have finished processing' do
         Video.create(zencoder_job_state: 'failed')
         Video.create(zencoder_job_state: 'processing')
+        Video.create(zencoder_job_state: 'playback_ready')
 
         match = Video.create(zencoder_job_state: 'finished')
 

--- a/spec/transmuxer/transmuxable_spec.rb
+++ b/spec/transmuxer/transmuxable_spec.rb
@@ -35,17 +35,5 @@ module Transmuxer
         expect(Video.ready).to eq([playback_ready, processed])
       end
     end
-
-    describe '.processed' do
-      it 'returns videos that have finished processing' do
-        Video.create(zencoder_job_state: 'failed')
-        Video.create(zencoder_job_state: 'processing')
-        Video.create(zencoder_job_state: 'playback_ready')
-
-        match = Video.create(zencoder_job_state: 'finished')
-
-        expect(Video.processed).to eq([match])
-      end
-    end
   end
 end

--- a/spec/transmuxer/transmuxable_spec.rb
+++ b/spec/transmuxer/transmuxable_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'active_record'
+
+class TestableObject < ActiveRecord::Base
+  include Transmuxer::Transmuxable
+  attr_accessor :zencoder_job_state
+end
+
+module Transmuxer
+  describe Transmuxable do
+    before(:each) do
+      Video.destroy_all
+    end
+
+    describe '.failed' do
+      it 'returns videos that failed processing' do
+        Video.create(zencoder_job_state: 'processing')
+        Video.create(zencoder_job_state: 'finished')
+
+        match = Video.create(zencoder_job_state: 'failed')
+
+        expect(Video.failed).to eq([match])
+      end
+    end
+
+    describe '.processed' do
+      it 'returns videos that have finished processing' do
+        Video.create(zencoder_job_state: 'failed')
+        Video.create(zencoder_job_state: 'processing')
+
+        match = Video.create(zencoder_job_state: 'finished')
+
+        expect(Video.processed).to eq([match])
+      end
+    end
+  end
+end

--- a/transmuxer.gemspec
+++ b/transmuxer.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = Dir["config/**/*", "lib/**/*.rb", "app/**/*", "LICENSE.txt", "README.md"]
+  spec.test_files    = Dir['spec/**/*']
   spec.require_paths = ["lib"]
 
   spec.add_dependency "zencoder", "~> 2.5.1"
@@ -23,4 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
To simplify finding collections of items that match a given state, several helper class methods have been added: `processed` and `failed`. These methods return `ActiveRecord::Relation` objects, which allow chaining with other subsequent scoping methods.

This update also adds a testing foundation using RSpec and sqlite (for testing Active Record models that mixin Transmuxable behavior).

cc: @alibilalaslam @hansef 
