### PR TITLE
Raise an error if transmux job fails to start

### DIFF
--- a/lib/transmuxer.rb
+++ b/lib/transmuxer.rb
@@ -5,6 +5,7 @@ require "transmuxer/version"
 require "transmuxer/config"
 require "transmuxer/job"
 require "transmuxer/transmuxable"
+require "transmuxer/error"
 
 require "transmuxer/engine"
 

--- a/lib/transmuxer/error.rb
+++ b/lib/transmuxer/error.rb
@@ -1,0 +1,5 @@
+module Transmuxer
+  class Error < StandardError; end
+
+  class JobNotStarted < Error; end
+end

--- a/lib/transmuxer/job.rb
+++ b/lib/transmuxer/job.rb
@@ -33,6 +33,10 @@ module Transmuxer
       started? && @job.body["id"]
     end
 
+    def errors
+      @job && @job.errors
+    end
+
     private
 
     def encoding_settings

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -37,6 +37,8 @@ module Transmuxer
       if job.start
         update_column :zencoder_job_id, job.id
         update_column :zencoder_job_state, "processing"
+      else
+        raise JobNotStarted, job.errors
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'transmuxer'
 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 
 require 'support/models'
+require 'support/notifications'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/support/notifications.rb
+++ b/spec/support/notifications.rb
@@ -1,0 +1,3 @@
+Transmuxer.config do |c|
+  c.notifications_host = "http://example.org"
+end

--- a/spec/transmuxer/transmuxable_spec.rb
+++ b/spec/transmuxer/transmuxable_spec.rb
@@ -36,4 +36,20 @@ module Transmuxer
       end
     end
   end
+
+  describe '#transmux' do
+    let(:video) { Video.create }
+
+    context 'when transmuxer job fails to start' do
+      let(:job) { double(:job, start: false, errors: "Oops!") }
+
+      before do
+        expect(Transmuxer::Job).to receive(:new) { job }
+      end
+
+      it do
+        expect { video.transmux }.to raise_error(Transmuxer::JobNotStarted, "Oops!")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Zencoder has been having intermittent issues where it fails to start an encoding job.

This update notifies the main app about the occurrence of this error.
