### PR TITLE
Video encoding improvements

### DIFF
--- a/lib/transmuxer/job.rb
+++ b/lib/transmuxer/job.rb
@@ -44,10 +44,52 @@ module Transmuxer
         input: input_url,
         outputs: [
           {
+            type: "segmented",
+            format: "aac",
+            audio_bitrate: 56,
+            audio_sample_rate: 22050,
+            base_url: output_store_path,
+            filename: "audio.m3u8",
+            public: true
+          },
+          {
+            label: "240p",
+            format: "mp4",
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 192,
+            decoder_bitrate_cap: 288,
+            decoder_buffer_size: 768,
+            h264_reference_frames: "auto",
+            forced_keyframe_rate: 0.1,
+            size: "426x240",
+            base_url: output_store_path,
+            filename: "240p.mp4",
+            public: true
+          },
+          {
+            label: "web-360p",
+            format: "mp4",
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 400,
+            decoder_bitrate_cap: 600,
+            decoder_buffer_size: 1600,
+            h264_reference_frames: "auto",
+            forced_keyframe_rate: 0.1,
+            size: "640x360",
+            base_url: output_store_path,
+            filename: "web-360p.mp4",
+            public: true
+          },
+          {
             label: "360p",
             format: "mp4",
-            quality: 3,
-            audio_quality: 3,
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 750,
+            decoder_bitrate_cap: 1125,
+            decoder_buffer_size: 3000,
             h264_reference_frames: "auto",
             forced_keyframe_rate: 0.1,
             size: "640x360",
@@ -56,10 +98,28 @@ module Transmuxer
             public: true
           },
           {
+            label: "480p",
+            format: "mp4",
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 1000,
+            decoder_bitrate_cap: 1500,
+            decoder_buffer_size: 4000,
+            h264_reference_frames: "auto",
+            forced_keyframe_rate: 0.1,
+            size: "854x480",
+            base_url: output_store_path,
+            filename: "480p.mp4",
+            public: true
+          },
+          {
             label: "720p",
             format: "mp4",
-            quality: 4,
-            audio_quality: 4,
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 2500,
+            decoder_bitrate_cap: 3750,
+            decoder_buffer_size: 10000,
             h264_reference_frames: "auto",
             forced_keyframe_rate: 0.1,
             size: "1280x720",
@@ -70,14 +130,81 @@ module Transmuxer
           {
             label: "1080p",
             format: "mp4",
-            quality: 5,
-            audio_quality: 5,
+            audio_bitrate: 128,
+            audio_sample_rate: 44100,
+            video_bitrate: 4500,
+            decoder_bitrate_cap: 6750,
+            decoder_buffer_size: 18000,
             h264_reference_frames: "auto",
             forced_keyframe_rate: 0.1,
             size: "1920x1080",
             base_url: output_store_path,
             filename: "1080p.mp4",
             public: true
+          },
+          {
+            label: "hls-240p",
+            source: "240p",
+            type: "segmented",
+            format: "ts",
+            copy_audio: true,
+            copy_video: true,
+            hls_optimized_ts: false,
+            instant_play: true,
+            base_url: output_store_path,
+            filename: "240p.m3u8",
+            public: true,
+            headers: {
+              "x-amz-acl" => "public-read"
+            },
+            access_control: [
+              {
+                permission: "FULL_CONTROL",
+                grantee: "aws@zencoder.com"
+              },
+              {
+                permission: "READ",
+                grantee: "http://acs.amazonaws.com/groups/global/AllUsers"
+              }
+            ],
+            notifications: [
+              {
+                event: "seamless_playback",
+                url: notifications_url
+              }
+            ]
+          },
+          {
+            label: "hls-web-360p",
+            source: "web-360p",
+            type: "segmented",
+            format: "ts",
+            copy_audio: true,
+            copy_video: true,
+            hls_optimized_ts: false,
+            instant_play: true,
+            base_url: output_store_path,
+            filename: "web-360p.m3u8",
+            public: true,
+            headers: {
+              "x-amz-acl" => "public-read"
+            },
+            access_control: [
+              {
+                permission: "FULL_CONTROL",
+                grantee: "aws@zencoder.com"
+              },
+              {
+                permission: "READ",
+                grantee: "http://acs.amazonaws.com/groups/global/AllUsers"
+              }
+            ],
+            notifications: [
+              {
+                event: "seamless_playback",
+                url: notifications_url
+              }
+            ]
           },
           {
             label: "hls-360p",
@@ -90,6 +217,38 @@ module Transmuxer
             instant_play: true,
             base_url: output_store_path,
             filename: "360p.m3u8",
+            public: true,
+            headers: {
+              "x-amz-acl" => "public-read"
+            },
+            access_control: [
+              {
+                permission: "FULL_CONTROL",
+                grantee: "aws@zencoder.com"
+              },
+              {
+                permission: "READ",
+                grantee: "http://acs.amazonaws.com/groups/global/AllUsers"
+              }
+            ],
+            notifications: [
+              {
+                event: "seamless_playback",
+                url: notifications_url
+              }
+            ]
+          },
+          {
+            label: "hls-480p",
+            source: "480p",
+            type: "segmented",
+            format: "ts",
+            copy_audio: true,
+            copy_video: true,
+            hls_optimized_ts: false,
+            instant_play: true,
+            base_url: output_store_path,
+            filename: "480p.m3u8",
             public: true,
             headers: {
               "x-amz-acl" => "public-read"
@@ -179,19 +338,39 @@ module Transmuxer
             type: "playlist",
             streams: [
               {
-                resolution: "640x360",
-                bandwidth: 256,
-                path: "360p.m3u8"
+                resolution: "1920x1080",
+                bandwidth: 5000,
+                path: "1080p.m3u8"
               },
               {
                 resolution: "1280x720",
-                bandwidth: 1024,
+                bandwidth: 2800,
                 path: "720p.m3u8"
               },
               {
-                resolution: "1920x1080",
-                bandwidth: 2048,
-                path: "1080p.m3u8"
+                resolution: "854x480",
+                bandwidth: 1400,
+                path: "480p.m3u8"
+              },
+              {
+                resolution: "640x360",
+                bandwidth: 1000,
+                path: "360p.m3u8"
+              },
+              {
+                resolution: "640x360",
+                bandwidth: 600,
+                path: "web-360p.m3u8"
+              },
+              {
+                resolution: "426x240",
+                bandwidth: 300,
+                path: "240p.m3u8"
+              },
+              {
+                bandwidth: 64,
+                path: "audio.m3u8",
+                codecs: "mp4a.40.5"
               }
             ],
             base_url: output_store_path,

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -116,7 +116,7 @@ module Transmuxer
     end
 
     def playable?
-      playable_formats.length == 3
+      playable_formats.length == 6
     end
 
     private

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -75,8 +75,20 @@ module Transmuxer
       "s3://#{Transmuxer.config.s3.bucket_name}/#{self.class.name.tableize}/#{id}/processed"
     end
 
+    def mp4_240_file_url
+      "#{processed_file_store_url}/240p.mp4"
+    end
+
+    def mp4_web_360_file_url
+      "#{processed_file_store_url}/web-360p.mp4"
+    end
+
     def mp4_360_file_url
       "#{processed_file_store_url}/360p.mp4"
+    end
+
+    def mp4_480_file_url
+      "#{processed_file_store_url}/480p.mp4"
     end
 
     def mp4_720_file_url


### PR DESCRIPTION
This update encodes videos so as to improve smooth playback for users on low bandwidth.

It adds an audio-only stream, 240p, web-360p (a lower bitrate 360p version), and 480p versions. In addition, it sets audio and video bitrates explicitly everywhere, instead of relying on zencoder quality settings, so we get more predictable behavior in terms of average bitrate.
