### PR TITLE
Acquire row-level lock before updating playable formats.

### DIFF
--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -51,9 +51,11 @@ module Transmuxer
     end
 
     def update_playable(playable_format)
-      self.playable_formats[playable_format] = true
-      self.zencoder_job_state = "playback_ready" if playable? && !processed?
-      self.save
+      self.with_lock do
+        self.playable_formats[playable_format] = true
+        self.zencoder_job_state = "playback_ready" if playable? && !processed?
+        self.save
+      end
 
       run_callbacks :playable if playable?
     end


### PR DESCRIPTION
This avoids race condition when Zencoder sends event notifications concurrently
to an application server that can handle concurrent requests
