### PR TITLE
Align the ready predicate method with named scope

### DIFF
--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -109,7 +109,7 @@ module Transmuxer
     end
 
     def ready?
-      processed? || playable?
+      %w(playback_ready finished).include?(zencoder_job_state)
     end
 
     def processed?

--- a/spec/transmuxer/transmuxable_spec.rb
+++ b/spec/transmuxer/transmuxable_spec.rb
@@ -52,4 +52,26 @@ module Transmuxer
       end
     end
   end
+
+  describe '#ready?' do
+    it 'returns true if video is ready' do
+      video = Video.create(zencoder_job_state: 'playback_ready')
+      expect(video.ready?).to be true
+    end
+
+    it 'returns true if video is finished' do
+      video = Video.create(zencoder_job_state: 'finished')
+      expect(video.ready?).to be true
+    end
+
+    it 'returns false if video is processing' do
+      video = Video.create(zencoder_job_state: 'processing')
+      expect(video.ready?).to be false
+    end
+
+    it 'returns false if video  failed' do
+      video = Video.create(zencoder_job_state: 'failed')
+      expect(video.ready?).to be false
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, the `ready?` method returned truthiness under a different set of conditions than the `ready` scope.

This update removes the check on playable formats length, in favor of checking only the same conditions as the `ready` scope – mainly if the video has a `zencoder_job_state` of either “playback_ready” or “finished”. Expecting these two methods to align seems like a reasonable expectation for models that include the mixin.
