### PR TITLE
Allow a cdn_host to be set in configuration [VH-36]

### DIFF
--- a/lib/transmuxer/config.rb
+++ b/lib/transmuxer/config.rb
@@ -4,7 +4,7 @@ module Transmuxer
   class Config
     include Singleton
 
-    attr_accessor :notifications_host
+    attr_accessor :notifications_host, :cdn_host
     attr_reader :s3, :zencoder
 
     def initialize
@@ -21,5 +21,6 @@ module Transmuxer
     class S3Config
       attr_accessor :bucket_name
     end
+
   end
 end

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -129,8 +129,16 @@ module Transmuxer
 
     private
 
+    def asset_url
+      if Transmuxer.config.cdn_host
+        "#{Transmuxer.config.cdn_host}"
+      else
+        "#{Transmuxer.config.s3.bucket_name}.s3.amazonaws.com"
+      end
+    end
+
     def processed_file_store_url
-      "https://#{Transmuxer.config.s3.bucket_name}.s3.amazonaws.com/#{self.class.name.tableize}/#{id}/processed"
+      "https://#{asset_url}/#{self.class.name.tableize}/#{id}/processed"
     end
 
     def notifications_url

--- a/lib/transmuxer/version.rb
+++ b/lib/transmuxer/version.rb
@@ -1,3 +1,3 @@
 module Transmuxer
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
This update adds a CDN configuration option of `cdn_host` to serve the video asset, falling back to the S3 url if not detected.

See [[VH-36]](http://jira.bletchley.co/browse/VH-36).
