### PR TITLE
Do not raise exceptions on skip_before_action

### DIFF
--- a/app/controllers/transmuxer/notifications_controller.rb
+++ b/app/controllers/transmuxer/notifications_controller.rb
@@ -1,6 +1,6 @@
 module Transmuxer
   class NotificationsController < ApplicationController
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token, raise: false
 
     def create
       if resource && resource.zencoder_job_id == params[:job][:id]


### PR DESCRIPTION
In Rails 5, when the method being skipped does not exist an exception is raised unless `raise: false` is passed to `skip_before_action`.
