### PR TITLE
Improve HLS playback

### DIFF
--- a/lib/transmuxer/job.rb
+++ b/lib/transmuxer/job.rb
@@ -77,28 +77,12 @@ module Transmuxer
           audio_constant_bitrate: true,
           video_bitrate: 192,
           decoder_bitrate_cap: 288,
-          decoder_buffer_size: 768,
+          decoder_buffer_size: 1152,
           h264_reference_frames: "auto",
           forced_keyframe_rate: 0.1,
           size: "426x240",
           base_url: output_store_path,
           filename: "240p.mp4",
-          public: true
-        },
-        {
-          label: "web-360p",
-          format: "mp4",
-          audio_bitrate: 128,
-          audio_sample_rate: 44100,
-          audio_constant_bitrate: true,
-          video_bitrate: 400,
-          decoder_bitrate_cap: 600,
-          decoder_buffer_size: 1600,
-          h264_reference_frames: "auto",
-          forced_keyframe_rate: 0.1,
-          size: "640x360",
-          base_url: output_store_path,
-          filename: "web-360p.mp4",
           public: true
         },
         {
@@ -109,7 +93,7 @@ module Transmuxer
           audio_constant_bitrate: true,
           video_bitrate: 750,
           decoder_bitrate_cap: 1125,
-          decoder_buffer_size: 3000,
+          decoder_buffer_size: 4500,
           h264_reference_frames: "auto",
           forced_keyframe_rate: 0.1,
           size: "640x360",
@@ -125,7 +109,7 @@ module Transmuxer
           audio_constant_bitrate: true,
           video_bitrate: 1000,
           decoder_bitrate_cap: 1500,
-          decoder_buffer_size: 4000,
+          decoder_buffer_size: 6000,
           h264_reference_frames: "auto",
           forced_keyframe_rate: 0.1,
           size: "854x480",
@@ -141,7 +125,7 @@ module Transmuxer
           audio_constant_bitrate: true,
           video_bitrate: 2500,
           decoder_bitrate_cap: 3750,
-          decoder_buffer_size: 10000,
+          decoder_buffer_size: 15000,
           h264_reference_frames: "auto",
           forced_keyframe_rate: 0.1,
           size: "1280x720",
@@ -157,7 +141,7 @@ module Transmuxer
           audio_constant_bitrate: true,
           video_bitrate: 4500,
           decoder_bitrate_cap: 6750,
-          decoder_buffer_size: 18000,
+          decoder_buffer_size: 27000,
           h264_reference_frames: "auto",
           forced_keyframe_rate: 0.1,
           size: "1920x1080",
@@ -175,31 +159,6 @@ module Transmuxer
           hls_optimized_ts: false,
           base_url: output_store_path,
           filename: "240p.m3u8",
-          public: true,
-          headers: {
-            "x-amz-acl" => "public-read"
-          },
-          access_control: [
-            {
-              permission: "FULL_CONTROL",
-              grantee: "aws@zencoder.com"
-            },
-            {
-              permission: "READ",
-              grantee: "http://acs.amazonaws.com/groups/global/AllUsers"
-            }
-          ]
-        },
-        {
-          label: "hls-web-360p",
-          source: "web-360p",
-          type: "segmented",
-          format: "ts",
-          copy_audio: true,
-          copy_video: true,
-          hls_optimized_ts: false,
-          base_url: output_store_path,
-          filename: "web-360p.m3u8",
           public: true,
           headers: {
             "x-amz-acl" => "public-read"
@@ -319,39 +278,24 @@ module Transmuxer
           type: "playlist",
           streams: [
             {
-              resolution: "1920x1080",
-              bandwidth: 5000,
+              source: "hls-1080p",
               path: "1080p.m3u8"
             },
             {
-              resolution: "1280x720",
-              bandwidth: 2800,
+              source: "hls-720p",
               path: "720p.m3u8"
             },
             {
-              resolution: "854x480",
-              bandwidth: 1400,
+              source: "hls-480p",
               path: "480p.m3u8"
             },
             {
-              resolution: "640x360",
-              bandwidth: 1000,
+              source: "hls-360p",
               path: "360p.m3u8"
             },
             {
-              resolution: "640x360",
-              bandwidth: 600,
-              path: "web-360p.m3u8"
-            },
-            {
-              resolution: "426x240",
-              bandwidth: 300,
+              source: "hls-240p",
               path: "240p.m3u8"
-            },
-            {
-              bandwidth: 64,
-              path: "audio.m3u8",
-              codecs: "mp4a.40.5"
             }
           ],
           base_url: output_store_path,

--- a/lib/transmuxer/transmuxable.rb
+++ b/lib/transmuxer/transmuxable.rb
@@ -88,10 +88,6 @@ module Transmuxer
       "#{processed_file_store_url}/240p.mp4"
     end
 
-    def mp4_web_360_file_url
-      "#{processed_file_store_url}/web-360p.mp4"
-    end
-
     def mp4_360_file_url
       "#{processed_file_store_url}/360p.mp4"
     end


### PR DESCRIPTION
This update addresses issues with HLS playback reverting to audio-only or lowest resolution stream even with ample bandwidth.

Bandwidth selection for each stream is delegated to Zencoder. This should ensure that the stream doesn't switch unnecessarily.

Audio-only stream is removed to buffer video instead of reverting to audio-only playback.